### PR TITLE
specifically set blockIds for blocks that were under the tilemaps namespace

### DIFF
--- a/overworld.ts
+++ b/overworld.ts
@@ -121,6 +121,7 @@ namespace tiles {
      * Copy an existing tilemap but without the connections.
      */
     //% block="copy $map"
+    //% blockId=tilemap_copyMap
     //% map.shadow=variables_get
     //% map.defl=tilemap
     //% group="Creation" weight=25 blockGap=8
@@ -137,6 +138,7 @@ namespace tiles {
      * Sets the current overworld tilemap.
      */
     //% block="set current tilemap to $map"
+    //% blockId=tilemap_loadMap
     //% map.shadow=create_overworld_map
     //% group="Creation" weight=40 blockGap=8
     export function loadMap(map: WorldMap) {
@@ -163,6 +165,7 @@ namespace tiles {
      * Returns the loaded overworld tilemap.
      */
     //% block="current tilemap"
+    //% blockId=tilemap_getLoadedMap
     //% group="Creation" weight=30
     export function getLoadedMap(): WorldMap {
         return OverWorldState.getInstance().loadedMap
@@ -172,6 +175,7 @@ namespace tiles {
      * Runs code when an overworld tilemap is loaded.
      */
     //% block="on tilemap loaded $tilemap"
+    //% blockId=tilemap_onMapLoaded
     //% draggableParameters="reporter"
     //% group="Creation" weight=20 blockGap=8
     export function onMapLoaded(cb: (tilemap: WorldMap) => void) {
@@ -184,6 +188,7 @@ namespace tiles {
      * Runs code when an overworld tilemap is unloaded.
      */
     //% block="on tilemap unloaded $tilemap"
+    //% blockId=tilemap_onMapUnloaded
     //% draggableParameters="reporter"
     //% group="Creation" weight=10 blockGap=8
     export function onMapUnloaded(cb: (tilemap: WorldMap) => void) {
@@ -211,6 +216,7 @@ namespace tiles {
      * Connections work in both ways and are remembered by both tilemaps.
      */
     //% block="connect $tilemap1 and $tilemap2 by $connection"
+    //% blockId=tilemap_connectMapById
     //% tilemap1.shadow=variables_get
     //% tilemap1.defl=tilemap1
     //% tilemap2.shadow=variables_get
@@ -227,6 +233,7 @@ namespace tiles {
      * given connection name or number.
      */
     //% block="load tilemap connected by $connection"
+    //% blockId=tilemap_loadConnectedMap
     //% connection.shadow=connection_kind
     //% group="Connections" weight=30 blockGap=8
     export function loadConnectedMap(connection: number) {
@@ -238,6 +245,7 @@ namespace tiles {
      * Gets the destination tilemap connected to the source tilemap by the given connection name or number.
      */
     //% block="get tilemap connected to $tilemap by $connection"
+    //% blockId=tilemap_getConnectedMap
     //% tilemap.shadow=variables_get
     //% tilemap.defl=tilemap
     //% connection.shadow=connection_kind

--- a/tilemap.ts
+++ b/tilemap.ts
@@ -46,6 +46,7 @@ namespace tiles {
      * will not collide with other sprites.
      */
     //% block="cover all $tileKind tiles with $cover"
+    //% blockId=tilemap_coverAllTiles
     //% tileKind.shadow=tileset_tile_picker
     //% tileKind.decompileIndirectFixedInstances=true
     //% cover.shadow=tileset_tile_picker
@@ -64,6 +65,7 @@ namespace tiles {
      * Useful to use with the "on created [...]" sprite block.
      */
     //% block="on each $tileKind tile create sprite of kind $spriteKind"
+    //% blockId=tilemap_createSpritesOnTiles
     //% tileKind.shadow=tileset_tile_picker
     //% tileKind.decompileIndirectFixedInstances=true
     //% spriteKind.shadow=spritekind
@@ -97,6 +99,7 @@ namespace tiles {
      * between tilemaps.
      */
     //% block="destroy all sprites of kind $spriteKind"
+    //% blockId=tilemap_destorySpritesOfKind
     //% spriteKind.shadow=spritekind
     //% group="Sprites" weight=9 blockGap=8
     export function destroySpritesOfKind(spriteKind: number) {
@@ -112,6 +115,7 @@ namespace tiles {
      * is of a particular kind.
      */
     //% block="tile at $location is $tile"
+    //% blockId=tilemap_tileIs
     //% location.shadow=mapgettile
     //% tile.shadow=tileset_tile_picker
     //% tile.decompileIndirectFixedInstances=true
@@ -125,6 +129,7 @@ namespace tiles {
      * is a wall.
      */
     //% block="tile at $location is wall"
+    //% blockId=tilemap_tileIsWall
     //% location.shadow=mapgettile
     //% group="Tiles" weight=79
     export function tileIsWall(location: tiles.Location): boolean {
@@ -181,6 +186,7 @@ namespace tiles {
      * another tile.
      */
     //% block="replace all $from tiles with $to"
+    //% blockId=tilemap_replaceAllTiles
     //% from.shadow=tileset_tile_picker
     //% from.decompileIndirectFixedInstances=true
     //% to.shadow=tileset_tile_picker
@@ -233,6 +239,7 @@ namespace tiles {
      * Center the camera on a given tile location.
      */
     //% block="center camera on $location"
+    //% blockId=tilemap_createCameraOnTile
     //% group="Camera" weight=10 blockGap=8
     //% location.shadow=mapgettile
     export function centerCameraOnTile(location: tiles.Location) {
@@ -247,6 +254,7 @@ namespace tiles {
      * Gets the tile location of a sprite.
      */
     //% block="location of $s"
+    //% blockId=tilemap_locationOfSprite
     //% s.shadow=variables_get
     //% s.defl=mySprite
     //% group="Location" weight=90 blockGap=8
@@ -310,6 +318,7 @@ namespace tiles {
      * Get's the world x or y position from a tile row column location.
      */
     //% block="$location $xy"
+    //% blockId=tilemap_locationXY
     //% location.shadow=variables_get
     //% location.defl=location
     //% group="Location" weight=45 blockGap=8
@@ -340,6 +349,7 @@ namespace tiles {
      * Starting from a tile location, get the neighboring tile location in the given direction.
      */
     //% block="location $direction of $location"
+    //% blockId=tilemap_locationInDirection
     //% direction.shadow=direction_editor
     //% location.shadow=variables_get
     //% location.defl=location
@@ -362,6 +372,7 @@ namespace tiles {
      * Returns the width of tiles in the loaded tilemap.
      */
     //% block="tile width"
+    //% blockId=tilemap_tileWidth
     //% group="Location" weight=15
     export function tileWidth(): number {
         const tm = game.currentScene().tileMap;
@@ -374,6 +385,7 @@ namespace tiles {
      * Returns the number of columns in the currently loaded tilemap.
      */
     //% block="total tilemap columns"
+    //% blockId=tilemap_tilemapColumns
     //% group="Location" weight=16 blockGap=8
     export function tilemapColumns(): number {
         const tm = game.currentScene().tileMap;
@@ -387,6 +399,7 @@ namespace tiles {
      * Returns the number of rows in the currently loaded tilemap.
      */
     //% block="total tilemap rows"
+    //% blockId=tilemap_tilemapRows
     //% group="Location" weight=17 blockGap=8
     export function tilemapRows(): number {
         const tm = game.currentScene().tileMap;


### PR DESCRIPTION
Add in block ids for every block that was under the tilemap namespace.

I had looked at them and saw blockIds on the first few, but the majority of these blocks didn't actually specify blockIds. This didn't make a difference due to the other issues I'm fixing caused it to bail out of blocks anyways, but it will when I fix those.

This sets the blockIds back to what they were when the namespace was `tilemap` instead of tiles.

Also, the blockId tilemap_destorySpritesOfKind is intentional, that function was misspelled before.